### PR TITLE
Add sellout loan and sellout insolvent loan functionality

### DIFF
--- a/test/integration/pangolin-exchange.test.ts
+++ b/test/integration/pangolin-exchange.test.ts
@@ -85,8 +85,8 @@ describe('PangolinExchange', () => {
     });
 
 
-    it('should revert transaction in case of a sufficient token balance transferred to an exchange', async () => {
-      await expect(sut.sellAsset(toBytes32('DAI'), toWei("1"), toWei("0.01"))).to.be.revertedWith('TransferHelper: TRANSFER_FROM_FAILED');
+    it('should revert transaction in case of an insufficient token balance transferred to an exchange', async () => {
+      await expect(sut.sellAsset(toBytes32('DAI'), toWei("1"), toWei("0.001"))).to.be.revertedWith('TransferHelper: TRANSFER_FROM_FAILED');
     });
 
 

--- a/tools/loans.js
+++ b/tools/loans.js
@@ -96,6 +96,16 @@ async function findAllLoans() {
   return loans;
 }
 
+
+async function selloutSolventLoan(loanAddress) {
+  let loan = new ethers.Contract(loanAddress, LOAN.abi, wallet);
+  loan = WrapperBuilder
+    .wrapLite(loan)
+    .usingPriceFeed("f1Ipos2fVPbxPVO65GBygkMyW0tkAhp2hdprRPPBBN8"); // redstone-avalanche
+  await loan.selloutLoan({gasLimit: 2000000});
+}
+
+
 async function getLoanStatus(loanAddress) {
   let loan = new ethers.Contract(loanAddress, LOAN.abi, wallet);
   loan = WrapperBuilder
@@ -120,5 +130,6 @@ module.exports = {
   borrowFromPool,
   invest,
   setMaxLTV,
-  loanSellout
+  loanSellout,
+  selloutSolventLoan
 };

--- a/tools/scripts/solvent-loans-sellout.js
+++ b/tools/scripts/solvent-loans-sellout.js
@@ -1,0 +1,11 @@
+const Loans = require('../loans.js');
+
+async function selloutAllLoans() {
+  let loans = await Loans.findAllLoans();
+  console.log(`Found ${loans.length} loans. Attempting to sell all of them out.`)
+  loans.forEach( async loanAddress => {
+    await Loans.selloutSolventLoan(loanAddress);
+  });
+}
+
+selloutAllLoans();


### PR DESCRIPTION
The goal of this task is to encapsulate the `sellout()` method by making it private and calling it from two newly introduced functions:
* `selloutLoan()` (onlyOwner) - sells out all assets, repays debt, returns remaining AVAX (if any) to the owner
* `selloutInsolventLoan()` (!isSolvent) - sells out just enough assets to bring a loan back to a solvent state. Pays out a liquidation bonus to the liquidator if possible.
